### PR TITLE
Add missing arglist to magit-gerrit-copy-review-popup

### DIFF
--- a/magit-gerrit.el
+++ b/magit-gerrit.el
@@ -508,7 +508,7 @@ Succeed even if branch already exist
 (transient-append-suffix 'magit-dispatch "%"
   (list magit-gerrit-popup-prefix "Gerrit" 'magit-gerrit-popup))
 
-(transient-define-prefix magit-gerrit-copy-review-popup
+(transient-define-prefix magit-gerrit-copy-review-popup ()
   "Popup console for copy review to clipboard."
   ["Copy review"
    ("C" "url and commit message" magit-gerrit-copy-review-url-commit-message)


### PR DESCRIPTION
Fix what has become a blocking error.

By the way, I'd be willing to be the maintainer for magit-gerrit.  I use it every day, so I have a vested interest in keeping it alive, and even improving it. I know there was a lot of discussion about this, but it seems it all was for nothing?