### PR TITLE
Optimize gerrit query cmd by removing comments and approvals

### DIFF
--- a/magit-gerrit.el
+++ b/magit-gerrit.el
@@ -124,8 +124,6 @@ Typical values would be \"publish\" or \"for\".")
 (defun magit-gerrit--query (prj &optional status)
   (magit-gerrit--command "query"
                          "--format=JSON"
-                         "--all-approvals"
-                         "--comments"
                          "--current-patch-set"
                          (concat "project:" prj)
                          (concat "status:" (or status "open"))))


### PR DESCRIPTION
Remove comments and all-approvals from Gerrit query command parameters. 

This limits the amount of the transferred data a lot in some usecases. As an example from one usecase this dropped data size from 11MB to 33K. Removing "--comments" and having --all-approvals gave 200K data in the same usecase. (sizes are taken from the output dump file sizes). Update times of magit status dropped from 10-20 sec to 2 sec or faster depending on project size. 

I am not sure if this is ok for all use cases, so this should be reviewed properly! 
