### PR TITLE
Download patchset should fetch from remote

### DIFF
--- a/magit-gerrit.el
+++ b/magit-gerrit.el
@@ -341,6 +341,7 @@ message and fetch the review data from gerrit."
             (branch (format "review/%s/%s"
                             (cdr (assoc 'username (assoc 'owner jobj)))
                             (cdr (or (assoc 'topic jobj) (assoc 'number jobj))))))
+        (magit-git-fetch magit-gerrit-remote ref)
         (message (format "Waiting a git fetch from %s to complete..."
                          magit-gerrit-remote))
         (magit-gerrit-process-wait)


### PR DESCRIPTION
When downloading a patchset, the branch is created from whatever FETCH_HEAD happens to point at and you do not get the intended patchset unless magit-gerrit-view-patchset-diff is called first.

Fix by calling magit-git-fetch, just like magit-gerrit-view-patchset-diff does.
