### PR TITLE
Make waiting for processes more explicit

### DIFF
--- a/magit-gerrit.el
+++ b/magit-gerrit.el
@@ -327,8 +327,8 @@ If PROCESS is nil, wait for `magit-this-process'."
             (dir default-directory))
         (with-temp-message (format "Waiting a git fetch from %s to complete..."
                                    magit-gerrit-remote)
-          (magit-git-fetch magit-gerrit-remote ref)
-          (magit-gerrit-process-wait))
+          (magit-gerrit-process-wait
+           (magit-git-fetch magit-gerrit-remote ref)))
         (message "Generating Gerrit Patchset for refs %s dir %s" ref dir)
         (apply #'magit-diff-setup-buffer
                "FETCH_HEAD~1..FETCH_HEAD" nil
@@ -346,8 +346,8 @@ If PROCESS is nil, wait for `magit-this-process'."
                             (cdr (or (assoc 'topic jobj) (assoc 'number jobj))))))
         (with-temp-message (format "Waiting a git fetch from %s to complete..."
                                    magit-gerrit-remote)
-          (magit-git-fetch magit-gerrit-remote ref)
-          (magit-gerrit-process-wait))
+          (magit-gerrit-process-wait
+           (magit-git-fetch magit-gerrit-remote ref)))
         (with-temp-message (format "Checking out refs %s to %s in %s" ref branch dir)
           (magit-gerrit-create-branch-force branch "FETCH_HEAD"))))))
 

--- a/magit-gerrit.el
+++ b/magit-gerrit.el
@@ -448,9 +448,9 @@ If PROCESS is nil, wait for `magit-this-process'."
                        (user-error "Couldn't find a commit at point")))
          (rev (magit-rev-parse (or commitid
                                    (user-error "Select a commit for review"))))
-         (branch-remote (and branch (magit-get "branch" branch "remote"))))
-    (let* ((branch-merge (if (or (null branch-remote)
-                                 (string= branch-remote "."))
+         (remote (and branch (magit-get "branch" branch "remote"))))
+    (let* ((branch-merge (if (or (null remote)
+                                 (string= remote "."))
                              (completing-read
                               "Remote Branch: "
                               (let ((rbs (magit-list-remote-branch-names)))
@@ -475,10 +475,10 @@ If PROCESS is nil, wait for `magit-this-process'."
                                  status
                                  (match-string 1 branch-merge)
                                  branch))))
-      (when (or (null branch-remote)
-                (string= branch-remote "."))
-        (setq branch-remote magit-gerrit-remote))
-      (magit-run-git-async "push" "-v" branch-remote
+      (when (or (null remote)
+                (string= remote "."))
+        (setq remote magit-gerrit-remote))
+      (magit-run-git-async "push" "-v" remote
                            (concat rev ":" branch-pub)))))
 
 (defun magit-gerrit-create-review ()

--- a/magit-gerrit.el
+++ b/magit-gerrit.el
@@ -310,9 +310,12 @@ message and fetch the review data from gerrit."
         (car (magit-gerrit--ssh-query (magit-gerrit-get-project)
                                       change-id)))))
 
-(defsubst magit-gerrit-process-wait ()
-  (while (and magit-this-process
-              (eq (process-status magit-this-process) 'run))
+(defsubst magit-gerrit-process-wait (&optional process)
+  "Wait for PROCESS to finish.
+If PROCESS is nil, wait for `magit-this-process'."
+  (setq process (or process magit-this-process))
+  (while (and process
+              (eq (process-status process) 'run))
     (sleep-for 0.005)))
 
 (defun magit-gerrit-view-patchset-diff ()

--- a/magit-gerrit.el
+++ b/magit-gerrit.el
@@ -529,24 +529,28 @@ If PROCESS is nil, wait for `magit-this-process'."
 
 (transient-define-prefix magit-gerrit-popup ()
   "Popup console for magit gerrit commands."
-  ["Options"
-   ("-m" "Comment" "--message "
-    :class transient-option
-    :reader magit-gerrit-read-comment)]
-  ["Actions"
-   ("P" "Push Commit For Review"       magit-gerrit-create-review)
-   ("W" "Push Commit For Draft Review" magit-gerrit-create-draft)
-   ("p" "Publish Draft Patchset"       magit-gerrit-publish-draft)
-   ("k" "Delete Draft"                 magit-gerrit-delete-draft)
-   ("A" "Add Reviewer"                 magit-gerrit-add-reviewer)
-   ("V" "Verify"                       magit-gerrit-verify-review)
-   ("c" "Copy Review"                  magit-gerrit-copy-review-popup)
-   ("C" "Code Review"                  magit-gerrit-code-review)
-   ("d" "View Patchset Diff"           magit-gerrit-view-patchset-diff)
-   ("D" "Download Patchset"            magit-gerrit-download-patchset)
-   ("S" "Submit Review"                magit-gerrit-submit-review)
-   ("B" "Abandon Review"               magit-gerrit-abandon-review)
-   ("b" "Browse Review"                magit-gerrit-browse-review)])
+   ["Options"
+    [("-m" "Comment" "--message "
+     :class transient-option
+     :reader magit-gerrit-read-comment)]]
+   [["Push"
+     ("P" "Push Commit For Review"       magit-gerrit-create-review)
+     ("W" "Push Commit For Draft Review" magit-gerrit-create-draft)
+     ("p" "Publish Draft Patchset"       magit-gerrit-publish-draft)]
+    ["Vote"
+     ("V" "Verify"                       magit-gerrit-verify-review)
+     ("c" "Copy Review"                  magit-gerrit-copy-review-popup)
+     ("C" "Code Review"                  magit-gerrit-code-review)
+     ]
+    ["Actions"
+     ("k" "Delete Draft"                 magit-gerrit-delete-draft)
+     ("A" "Add Reviewer"                 magit-gerrit-add-reviewer)
+     ("S" "Submit Review"                magit-gerrit-submit-review)
+     ("B" "Abandon Review"               magit-gerrit-abandon-review)]
+    ["View"
+     ("d" "View Patchset Diff"           magit-gerrit-view-patchset-diff)
+     ("D" "Download Patchset"            magit-gerrit-download-patchset)
+     ("b" "Browse Review"                magit-gerrit-browse-review)]])
 
 (defun magit-gerrit-arguments ()
   (or (transient-args 'magit-gerrit-popup)

--- a/magit-gerrit.el
+++ b/magit-gerrit.el
@@ -448,7 +448,7 @@ If PROCESS is nil, wait for `magit-this-process'."
                        (user-error "Couldn't find a commit at point")))
          (rev (magit-rev-parse (or commitid
                                    (user-error "Select a commit for review"))))
-         (remote (and branch (magit-get "branch" branch "remote"))))
+         (remote (magit-get "branch" branch "remote")))
     (let* ((branch-merge (if (or (null remote)
                                  (string= remote "."))
                              (completing-read

--- a/magit-gerrit.el
+++ b/magit-gerrit.el
@@ -334,6 +334,10 @@ If PROCESS is nil, wait for `magit-this-process'."
                "FETCH_HEAD~1..FETCH_HEAD" nil
                (magit-diff-arguments))))))
 
+(defun magit-gerrit-review-number-at-point ()
+  "Return the Gerrit review number of the review at point."
+  (cdr (assoc 'number (magit-gerrit-review-at-point))))
+
 (defun magit-gerrit-download-patchset ()
   "Download a Gerrit Review Patchset."
   (interactive)

--- a/magit-gerrit.el
+++ b/magit-gerrit.el
@@ -322,11 +322,11 @@ message and fetch the review data from gerrit."
     (when jobj
       (let ((ref (cdr (assoc 'ref (assoc 'currentPatchSet jobj))))
             (dir default-directory))
-        (magit-git-fetch magit-gerrit-remote ref)
-        (message (format "Waiting a git fetch from %s to complete..."
-                         magit-gerrit-remote))
-        (magit-gerrit-process-wait)
-        (message (format "Generating Gerrit Patchset for refs %s dir %s" ref dir))
+        (with-temp-message (format "Waiting a git fetch from %s to complete..."
+                                   magit-gerrit-remote)
+          (magit-git-fetch magit-gerrit-remote ref)
+          (magit-gerrit-process-wait))
+        (message "Generating Gerrit Patchset for refs %s dir %s" ref dir)
         (apply #'magit-diff-setup-buffer
                "FETCH_HEAD~1..FETCH_HEAD" nil
                (magit-diff-arguments))))))
@@ -341,12 +341,12 @@ message and fetch the review data from gerrit."
             (branch (format "review/%s/%s"
                             (cdr (assoc 'username (assoc 'owner jobj)))
                             (cdr (or (assoc 'topic jobj) (assoc 'number jobj))))))
-        (magit-git-fetch magit-gerrit-remote ref)
-        (message (format "Waiting a git fetch from %s to complete..."
-                         magit-gerrit-remote))
-        (magit-gerrit-process-wait)
-        (message (format "Checking out refs %s to %s in %s" ref branch dir))
-        (magit-gerrit-create-branch-force branch "FETCH_HEAD")))))
+        (with-temp-message (format "Waiting a git fetch from %s to complete..."
+                                   magit-gerrit-remote)
+          (magit-git-fetch magit-gerrit-remote ref)
+          (magit-gerrit-process-wait))
+        (with-temp-message (format "Checking out refs %s to %s in %s" ref branch dir)
+          (magit-gerrit-create-branch-force branch "FETCH_HEAD"))))))
 
 (defun magit-gerrit-browse-review ()
   "Browse the Gerrit Review with a browser."

--- a/magit-gerrit.el
+++ b/magit-gerrit.el
@@ -112,7 +112,7 @@ Typical values would be \"publish\" or \"for\".")
   (let ((gcmd (concat
                "-x -p 29418 "
                (or magit-gerrit-ssh-creds
-                   (error "`magit-gerrit-ssh-creds' must be set!"))
+                   (user-error "`magit-gerrit-ssh-creds' must be set!"))
                " "
                "gerrit "
                cmd
@@ -443,11 +443,11 @@ If PROCESS is nil, wait for `magit-this-process'."
 
 (defun magit-gerrit-push-review (status)
   (let* ((branch (or (magit-get-current-branch)
-                     (error "Don't push a detached head.  That's gross")))
+                     (user-error "Don't push a detached head.  That's gross")))
          (commitid (or (magit-section-value-if 'commit)
-                       (error "Couldn't find a commit at point")))
+                       (user-error "Couldn't find a commit at point")))
          (rev (magit-rev-parse (or commitid
-                                   (error "Select a commit for review"))))
+                                   (user-error "Select a commit for review"))))
          (branch-remote (and branch (magit-get "branch" branch "remote"))))
     (let* ((branch-merge (if (or (null branch-remote)
                                  (string= branch-remote "."))
@@ -566,11 +566,11 @@ If PROCESS is nil, wait for `magit-this-process'."
   "Gerrit support for Magit."
   :lighter " Gerrit" :require 'magit-topgit :keymap 'magit-gerrit-mode-map
   (unless (derived-mode-p 'magit-mode)
-    (error "This mode only makes sense with magit"))
+    (user-error "This mode only makes sense with magit"))
   (unless magit-gerrit-ssh-creds
-    (error "You *must* set `magit-gerrit-ssh-creds' to enable magit-gerrit-mode"))
+    (user-error "You *must* set `magit-gerrit-ssh-creds' to enable magit-gerrit-mode"))
   (unless (magit-gerrit-get-remote-url)
-    (error "You *must* set `magit-gerrit-remote' to a valid Gerrit remote"))
+    (user-error "You *must* set `magit-gerrit-remote' to a valid Gerrit remote"))
   (cond
    (magit-gerrit-mode
     (magit-add-section-hook 'magit-status-sections-hook


### PR DESCRIPTION
Do not rely on the `magit-this-process` variable but use the process object returned by `magit-git-fetch`.

